### PR TITLE
Force diff encoding to UTF-8.

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -545,7 +545,7 @@ module Gollum
 
       def diff(sha1, sha2, path = nil)
         opts = path == nil ? {} : {:path => path}
-        @repo.diff(sha1, sha2, opts).patches.map  {|patch| OpenStruct.new(:diff => patch.to_s.split("\n")[2..-1].join("\n"))}.reverse # First remove two superfluous lines. Rugged seems to order the diffs differently than Grit, so reverse.
+        @repo.diff(sha1, sha2, opts).patches.map  {|patch| OpenStruct.new(:diff => patch.to_s.split("\n")[2..-1].join("\n").force_encoding("UTF-8"))}.reverse # First remove two superfluous lines. Rugged seems to order the diffs differently than Grit, so reverse.
       end
       
       def log(commit = 'refs/heads/master', path = nil, options = {})


### PR DESCRIPTION
Grit always returns strings tagged as UTF-8, but Rugged returns them as ASCII-8BIT. Gollum assumes UTF-8, and without any encoding changes concatenates the diff lines with UTF-8-encoded strings, which leads to an error if other strings contain non-ASCII characters.