### PR TITLE
Fix version comparisons and latest changes view

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -110,7 +110,7 @@ module Gollum
       end
       
       def authored_date
-        @commit.time
+        @commit.author[:time]
       end
       
       def message

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -138,7 +138,7 @@ module Gollum
           additions += new_additions
           deletions += new_deletions
           total += patch.changes
-          files << [patch.delta.new_file[:path], new_deletions, new_additions, patch.changes] # Rugged seems to generate the stat diffs in the other direciton than grit does by default, so switch the order of additions and deletions.
+          files << [patch.delta.new_file[:path].force_encoding("UTF-8"), new_deletions, new_additions, patch.changes] # Rugged seems to generate the stat diffs in the other direciton than grit does by default, so switch the order of additions and deletions.
         end
         OpenStruct.new(:additions => additions, :deletions => deletions, :files => files, :id => id, :total => total)
       end

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -132,9 +132,11 @@ module Gollum
         deletions = 0
         total = 0
         files = []
-        diff = @commit.diff.each_patch do |patch|
-          new_additions = patch.stat[0]
-          new_deletions = patch.stat[1]
+        parent = @commit.parents.first
+        diff = Rugged::Tree.diff(@commit.tree.repo, parent ? parent.tree : nil, @commit.tree)
+        diff = diff.each_patch do |patch|
+          new_additions = patch.stat[1]
+          new_deletions = patch.stat[0]
           additions += new_additions
           deletions += new_deletions
           total += patch.changes


### PR DESCRIPTION
These commits fix multiple problems with version comparison (showing diffs of incorrect files) and latest changes views (colorful screen of death, incorrect dates, too many files listed). Now it works quite well.