### PR TITLE
Respect pagination options in `Git#versions_for_path`. Resolves #10.

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -223,8 +223,6 @@ module Gollum
       end
 
       def versions_for_path(path = nil, ref = nil, options = {})
-        options.delete :max_count
-        options.delete :skip
         log(ref, path, options)
       end
       


### PR DESCRIPTION
So, here is the pull request announced in #10.

I have run both the `adapter_specs` and the `gollum-lib` specs, on MRI 2.2.3, and they passed. 