### PR TITLE
A few one-line enhancements. Closes #11.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+coverage

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -450,6 +450,7 @@ module Gollum
         actor = Gollum::Git::Actor.default_actor if actor.nil?
         commit_options[:tree] = @index.write_tree
         commit_options[:author] = actor.to_h
+        commit_options[:committer] = actor.to_h
         commit_options[:message] = message.to_s
         commit_options[:parents] = parents
         commit_options[:update_ref] = head

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -478,7 +478,7 @@ module Gollum
 
       def get_parents(parents, head)
         if parents
-          parents.map!{|parent| parent.commit} if parents
+          parents.map{|parent| parent.commit}
         elsif ref = @rugged_repo.references[head]
           ref = ref.target
           ref = ref.target if ref.respond_to?(:target)


### PR DESCRIPTION
There are three logical changes in this pull request:

 * A `.gitignore` file was added, to ignore `Gemfile.lock` and `coverage` (same as [`grit_adapter`](https://github.com/gollum/grit_adapter/blob/v1.0.0/.gitignore));
 * The `:committer` information is set, to the same information as `:author` - closes #11;
 * The `Index#get_parents` method modified the `parents` argument - but, in the use that is made by [`Gollum::Committer`](https://github.com/gollum/gollum-lib/blob/v4.1.0/lib/gollum-lib/committer.rb#L170), the `parents` array would be modified to contain an array of `Rugged::Commit` objects instead of `Gollum::Git::Commit` objects - that seemed weird and undesirable to me;

Now, these three should be separate issues, but I will confess that I did not feel like making two issue tickets for what, to me, feel like obvious improvements. If you feel that there is matter for a debate, feel free to tell me and I will open a separate issue, and amend this PR as necessary.