### PR TITLE
update rugged dependency for 0.25

### DIFF
--- a/rugged_adapter.gemspec
+++ b/rugged_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Rugged (libgit2) at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'rugged', '~> 0.24.0', '>=0.21.3'
+  s.add_runtime_dependency 'rugged', '~> 0.25.0'
   s.add_runtime_dependency 'mime-types', '>= 1.15'
   s.add_development_dependency "rspec", "3.4.0"  
 


### PR DESCRIPTION
fixes using rugged 0.25

https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/8538#note_21302761

please release new version as well when merged

also closes #18 once merged (altho it could be already closed as #17 is merged)