### PR TITLE
Specify less strict version requirement for rugged

### DIFF
--- a/rugged_adapter.gemspec
+++ b/rugged_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Rugged (libgit2) at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'rugged', '~> 0.25.0'
+  s.add_runtime_dependency 'rugged', '~> 0.25'
   s.add_runtime_dependency 'mime-types', '>= 1.15'
   s.add_development_dependency "rspec", "3.4.0"  
 


### PR DESCRIPTION
As described in https://github.com/gollum/rugged_adapter/pull/22#issuecomment-273095720, both gems (`gollum-rugged_adapter` and `rugged`) are before `1.0.0` which means that semantic versioning does not apply anyway.

Changes between `rugged` 0.25.0 and 0.25.1 may be as unexpected as between 0.25.1 and 0.26.0, so it does not make sense to be so strict about the version anyway.