### PR TITLE
Returning nil if the current dir is not found

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -388,12 +388,7 @@ module Gollum
         tmp_entry = nil
 
         pathname.each_filename do |dir|
-          tmp_entry = if tmp_entry.nil?
-                        commit.tree[dir]
-                      else
-                        @repo.lookup(tmp_entry[:oid])[dir]
-                      end
-
+          tmp_entry = tmp_entry ? @repo.lookup(tmp_entry[:oid])[dir] : commit.tree[dir]
           return nil unless tmp_entry
         end
         tmp_entry

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -388,11 +388,13 @@ module Gollum
         tmp_entry = nil
 
         pathname.each_filename do |dir|
-          if tmp_entry.nil?
-            return nil unless (tmp_entry = commit.tree[dir])
-          else
-            tmp_entry = @repo.lookup(tmp_entry[:oid])[dir]
-          end
+          tmp_entry = if tmp_entry.nil?
+                        commit.tree[dir]
+                      else
+                        @repo.lookup(tmp_entry[:oid])[dir]
+                      end
+
+          return nil unless tmp_entry
         end
         tmp_entry
       end


### PR DESCRIPTION
It seems there is a problem with versions when a gollum_page is moved to a different directory using git. The steps to reproduce is this:

- Create, commit and push a page using git. The resulting commit is this:
```
#<Rugged::Commit:70290450406820 {message: "created page\n", tree: #<Rugged::Tree:70290494148420 {oid: 170e8a2300ca1c43c133bc02e16c15724981a5e9}>
  <"home.md" 953595a3b0f9380b0a3c2c19f476fed1e0ca76f0>
  <"bar.md" b118ce62192eb7b04549ff3211ee1a5efb4a50a2>
, parents: ["51bec78e7c496570b7406fdbb44312cf9a9fa7ce"]}>
```
This commit id is: `0d4343068b0ccd219808015ddf020563d0d6c348`.

- Now, move the gollum_page to a different directory, in this example would be `foo/bar.md`. The resulting commit is:
```
#<Rugged::Commit:70290397004820 {message: "moved page\n", tree: #<Rugged::Tree:70290492778640 {oid: 284af6d41890c766d3c4f7910268517001c1c1e8}>
  <"home.md" 953595a3b0f9380b0a3c2c19f476fed1e0ca76f0>
  <"foo" 9dfcfd23aa2fe51b4c51128999959ab1929febd8>
, parents: ["0d4343068b0ccd219808015ddf020563d0d6c348"]}>
```
This commit id is: `195ce8d51dcaa49182e7b825cd2fd985b80195b0`

- Now let ask the gollum_page about the versions:
```
gollum_page.last_version.id = 0d4343068b0ccd219808015ddf020563d0d6c348 # Points to the create commit
gollum_page.version.id = 195ce8d51dcaa49182e7b825cd2fd985b80195b0 # Points to the move commit
```
The problem is due to the `tree_entry` method which returns that there is a valid entry for `foo/bar.md ` in the create commit, which is not true. That makes that `commit_touches_path?` for the move commit returns false and hence the commit added to the `build_log`method is only the create one. 

In this PR, what I do is returning `nil` if the current_commit does not have the `dir`, then the `commit_touches_path?` will return true and the `build_log` will add the move commit. This way the `last_version` and `version` of the gollum page will be pointing to the same commit.