### PR TITLE
Implement new revert method. Resolves #15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 gem 'rake', '~> 10.4.2'
+gem 'rugged', :github => 'libgit2/rugged', :submodules => true
 gem 'adapter_specs', git: 'https://github.com/gollum/adapter_specs.git'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 gem 'rake', '~> 10.4.2'
-gem 'rugged', :github => 'libgit2/rugged', :submodules => true
 gem 'adapter_specs', git: 'https://github.com/gollum/adapter_specs.git'
 
 group :test do

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -191,7 +191,7 @@ module Gollum
       def revert_path(path, sha1, sha2)
         patch = @repo.diff(sha2, sha1).first.diff
         begin
-          @repo.apply(patch, {:location => :index, :path => path)
+          @repo.apply(patch, {:location => :index, :path => path})
         rescue RuntimeError
           return false
         end
@@ -201,11 +201,11 @@ module Gollum
       def revert_commit(sha1, sha2)
         index = @repo.revert_commit(sha2, sha1)
         diff = @repo.diff(sha2, sha1)
-        files = []
+        paths = []
         diff.each_delta do |delta|
-          files << delta.new_file[:path]
+          paths << delta.new_file[:path]
         end
-        return index.write_tree(@repo), files
+        return index.write_tree(@repo), paths
       end
 
       def checkout(path, ref = 'HEAD', options = {})

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -190,14 +190,14 @@ module Gollum
 
       def revert(path, sha1, sha2)
         options = {}
-        options[:paths] = [path] if path
-        patch = path ?
-          @repo.diff(sha2, sha1, options).first.diff : @repo.diff(sha2, sha1)
         options[:location] = :index
         files = []
         if path
+          options[:paths] = [path]
+          patch = @repo.diff(sha2, sha1, options).first.diff
           files << path
         else
+          patch = @repo.diff(sha2, sha1)
           patch.each_delta do |delta|
             files << delta.new_file[:path]
             files << delta.old_file[:path]
@@ -205,9 +205,9 @@ module Gollum
         end
         files.uniq!
         begin
-          result = @repo.apply(patch, options)
+          @repo.apply(patch, options)
         rescue RuntimeError
-          result = false
+          return false
         end
         return false unless result
         return @repo.index.write_tree, files

--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -209,7 +209,6 @@ module Gollum
         rescue RuntimeError
           return false
         end
-        return false unless result
         return @repo.index.write_tree, files
       end
 

--- a/rugged_adapter.gemspec
+++ b/rugged_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Rugged (libgit2) at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'rugged', '~> 0.25'
+  s.add_runtime_dependency 'rugged', '~> 0.28', '>= 0.28.2'
   s.add_runtime_dependency 'mime-types', '>= 1.15'
   s.add_development_dependency "rspec", "3.4.0"  
 


### PR DESCRIPTION
Implements the `Git#revert` method. Requires changes to gollum-lib to work, see [here](https://github.com/gollum/gollum-lib/pull/325).

Todo:
- [x] Wait for new rugged release
- [ ] Update version
- [ ] Cut new version of gem