### PR TITLE
Add rev_parse(spec)

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -629,6 +629,10 @@ module Gollum
         results
       end
 
+      def rev_parse(spec)
+        @repo.rev_parse(spec)
+      end
+
       def path
         @repo.path
       end


### PR DESCRIPTION
This will followed by another PR in gollum-lib, which provides an efficient way to get SHA1 of a given path:

```
module Gollum
  class Wiki
    def rev_parse(path, rev = @ref)
      spec = "#{rev}:#{path}"
      @repo.rev_parse(spec)
    end
  end
end
```