### PR TITLE
Use `File.exist?` instead of `File.exists?`

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -168,7 +168,7 @@ module Gollum
       end
 
       def exist?
-        ::File.exists?(@repo.path)
+        ::File.exist?(@repo.path)
       end
 
       def grep(search_terms, options={}, &block)


### PR DESCRIPTION
This PR suppresses the following deprecation warning displayed by gollum-lib CI.
```
/home/runner/work/gollum-lib/gollum-lib/vendor/bundle/ruby/3.0.0/gems/gollum-rugged_adapter-1.1.2/lib/rugged_adapter/git_layer_rugged.rb:171: warning: File.exists? is deprecated; use File.exist? instead
```
`File.exists?` is being removed in Ruby 3.2.