### PR TITLE
Remove `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.7.0
-  - 3.0.0


### PR DESCRIPTION
This project uses GitHub Actions now, so `.travis.yml` can be removed.