### PR TITLE
Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/gollum-rugged_adapter.svg)](http://badge.fury.io/rb/gollum-rugged_adapter)
 ![Build Status](https://github.com/gollum/rugged_adapter/actions/workflows/test.yaml/badge.svg)
-[![Dependency Status](https://gemnasium.com/gollum/rugged_adapter.svg)](https://gemnasium.com/gollum/rugged_adapter)
 
 ## DESCRIPTION
 


### PR DESCRIPTION
gemnasium.com was closed on May 15, 2018.
https://gitlab-docs.creationline.com/ee/user/project/import/gemnasium.html

(If an alternative is needed, there is Dependabot.)