### PR TITLE
Update dependency to rugged ~> 1.5.0 for Ruby 3.2 support

### DIFF
--- a/rugged_adapter.gemspec
+++ b/rugged_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Rugged (libgit2) at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'rugged', '~> 1.1.0'
+  s.add_runtime_dependency 'rugged', '~> 1.5.0'
   s.add_runtime_dependency 'mime-types', '~> 1.15'
   s.add_development_dependency 'rspec', "3.4.0"
 


### PR DESCRIPTION
Related to https://github.com/gollum/gollum/issues/1928