### PR TITLE
Relax rugged dependency

### DIFF
--- a/rugged_adapter.gemspec
+++ b/rugged_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Rugged (libgit2) at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'rugged', '~> 1.5.0'
+  s.add_runtime_dependency 'rugged', '~> 1.5'
   s.add_runtime_dependency 'mime-types', '~> 1.15'
   s.add_development_dependency 'rspec', "3.4.0"
 


### PR DESCRIPTION
I think there's no need to be so strict, and we can trust `rugged` to follow SemVer properly.