### PR TITLE
Update mime-types gem

### DIFF
--- a/rugged_adapter.gemspec
+++ b/rugged_adapter.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Rugged (libgit2) at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'rugged', '~> 1.5'
-  s.add_runtime_dependency 'mime-types', '~> 1.15'
+  s.add_runtime_dependency 'rugged', '~> 1.5.0'
+  s.add_runtime_dependency 'mime-types', '~> 3.4'
   s.add_development_dependency 'rspec', "3.4.0"
 
   s.files         = Dir['lib/**/*.rb'] + ["README.md", "Gemfile"]


### PR DESCRIPTION
I tested the one method from the `mime-types` gem that we use (`MIME.Type_for(name)`) and it works after the update.