### PR TITLE
Implement Index#workdir_path_modified?

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -491,6 +491,14 @@ module Gollum
         @treemap = {}
       end
 
+      # Determines whether a path in the working directory has been modified compared to the index: i.e., is new, or has new content.
+      # The purpose of this method is to determine whether it is safe to overwrite a path with information from the index.
+      # Hence, when path does not exist in the workdir (:worktree_deleted), this method returns false.
+      def workdir_path_modified?(path)
+        return false if @rugged_repo.bare?
+        !(@rugged_repo.status(path) & [:worktree_modified, :worktree_new]).empty?
+      end
+
       def delete(path)
         @index.remove_all(path)
         update_treemap(path, false)


### PR DESCRIPTION
Implements the method defined in https://github.com/gollum/adapter_specs/pull/18. This PR should be rerun against the specs when https://github.com/gollum/adapter_specs/pull/18 is merged.

The purpose of this method is to aid in solving https://github.com/gollum/gollum/issues/1975