### PR TITLE
Get all directory entries at the given SHA

### DIFF
--- a/lib/rugged_adapter/git_layer_rugged.rb
+++ b/lib/rugged_adapter/git_layer_rugged.rb
@@ -659,6 +659,12 @@ module Gollum
         results
       end
 
+      def lstree_all_directories(sha)
+        @repo.lookup(sha).tree.each_tree.map { |rugged_tree_entry|
+          ::Gollum::Git::Tree.tree_entry_from_rugged_hash rugged_tree_entry
+        }
+      end
+
       def path
         @repo.path
       end


### PR DESCRIPTION
It looks like this gem has no test suite, so I've included the output from `@repo.lstree_all_directories(sha)` below as evidence that this works--until this can be tested at the `gollum-lib` and `gollum` layers.

---

This commit adds Gollum-formatted entries that represent the directory tree of the repository at the given SHA. For example, using the Gollum `lotr.git` test wiki, we get the following array back:

    @repo.lstree_all_directories(sha)
    =>
    [{:sha=>"6e48abfc56565574859e081ee58eae655d48cf71",
      :mode=>16384,
      :type=>"tree",
      :name=>"Gondor",
      :path=>"Gondor"},
     {:sha=>"760982a3b84987919b99748d87c7890bb54afd07",
      :mode=>16384,
      :type=>"tree",
      :name=>"Mordor",
      :path=>"Mordor"},
     {:sha=>"a13e77aca82edd8e6bd4096e351627859f74ffec",
      :mode=>16384,
      :type=>"tree",
      :name=>"Rivendell",
      :path=>"Rivendell"}]

In subsequent commits to `gollum` and `gollum-lib`, using this method can help us make Gollum's "Overview" page more performant for large wikis.

Currently, Gollum has no mechanism for getting the directory tree of the git repository, meaning we have to reverse-engineer the directory tree by using the paths of files checked into the repository.
